### PR TITLE
Fix pak switching.

### DIFF
--- a/src/api/m64p_plugin.h
+++ b/src/api/m64p_plugin.h
@@ -138,7 +138,7 @@ typedef struct {
 typedef struct {
     int Present;
     int RawData;
-    int  Plugin;
+    int Plugin;
 } CONTROL;
 
 typedef union {

--- a/src/backends/plugins_compat/plugins_compat.h
+++ b/src/backends/plugins_compat/plugins_compat.h
@@ -44,6 +44,8 @@ struct controller_input_compat
     struct transferpak* tpk;
 
     uint32_t last_input;
+    int last_pak_type;
+    void (*main_switch_pak)(int control_id);
     unsigned int pak_switch_delay;
     unsigned int gb_switch_delay;
 

--- a/src/main/main.h
+++ b/src/main/main.h
@@ -56,7 +56,7 @@ void new_frame(void);
 void new_vi(void);
 
 void main_switch_next_pak(int control_id);
-void main_switch_specific_pak(int control_id, int pakType);
+void main_switch_plugin_pak(int control_id);
 void main_change_gb_cart(int control_id);
 
 int  main_set_core_defaults(void);

--- a/src/main/main.h
+++ b/src/main/main.h
@@ -55,7 +55,8 @@ const char* get_savesrampath(void);
 void new_frame(void);
 void new_vi(void);
 
-void main_switch_pak(int control_id);
+void main_switch_next_pak(int control_id);
+void main_switch_specific_pak(int control_id, int pakType);
 void main_change_gb_cart(int control_id);
 
 int  main_set_core_defaults(void);

--- a/src/plugin/plugin.h
+++ b/src/plugin/plugin.h
@@ -31,7 +31,8 @@ extern m64p_error plugin_connect(m64p_plugin_type, m64p_dynlib_handle plugin_han
 extern m64p_error plugin_start(m64p_plugin_type);
 extern m64p_error plugin_check(void);
 
-extern CONTROL Controls[4];
+enum { NUM_CONTROLLER = 4 };
+extern CONTROL Controls[NUM_CONTROLLER];
 
 /*** Version requirement information ***/
 #define RSP_API_VERSION   0x20000


### PR DESCRIPTION
- Avoid usage of static variables inside input_plugin_get_input
- The last compatible pak entry must be the NULL/NONE to allow proper
cycling in main_switch_next_pak (as it acts has a sentinel).
- Fix pak switch delay expiration test: (delay > 0) && (--delay == 0)
- Minor edits